### PR TITLE
Refactor `for` loops and `Falsy` checks

### DIFF
--- a/scripts/pointshifter-beta.py
+++ b/scripts/pointshifter-beta.py
@@ -21,9 +21,9 @@ def xOPQ(stemAdjustment):
                     noShiftingLeft=False
                     print("left contour points moved by "+str(stemAdjustment)+ " points")
 
-            if noShiftingRight is False:
+            if not noShiftingRight:
                 glyph.rightMargin+=stemAdjustment*1.2
-            if noShiftingLeft is False:
+            if not noShiftingLeft:
                 glyph.leftMargin+=stemAdjustment*1.2
         
         glyph.changed()    


### PR DESCRIPTION
Extremely minor nitpicks while I was reading the code, couldn't help myself 😜  ... you'd just have to run and double-check that I didn't break anything!

* `For` loops in python work differently than in other languages. They're [actually `forEach` loops](https://treyhunner.com/2019/06/loop-better-a-deeper-look-at-iteration-in-python/#Review:_Python%E2%80%99s_for_loop) and so don't need that index pattern to access the elements of the thing being iterated over

* Lookup [Truthy v. Falsy](https://stackoverflow.com/questions/39983695/what-is-truthy-and-falsy-how-is-it-different-from-true-and-false) in Python. Really nice little tricks to clean up checks 😉 