### PR TITLE
Add fontParts to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/googlefonts/fontbakery
 git+https://github.com/googlefonts/gftools
 fontmake
+fontParts


### PR DESCRIPTION
The build script calls a Python script that uses [fontParts](https://github.com/robotools/fontParts), so it should be included in requirements.txt

Note, the script using fontParts is here: `sources/designspaces/WEIGHTWIDTHGRADE/matchGrades.py`